### PR TITLE
README 수정, static shortcut 추가, spell 오류 해결 등

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ $str = ReadableURL::gen();
 
 This can be used to add to the end of a URL.
 
-Example: https://example.com/photos/ForgetfulHarshEgg
+Example: `https://example.com/photos/ForgetfulHarshEgg`
 
 For best results, use an integer value of 3, 4, or 5.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Generate readable random phrases for URLs
 This library is available on packagist.
 To install, 
 ```shell script
-composer require readable-url
+composer require hyungju/readable-url
 ``` 
 
 Then create ``ReadableURL`` Class
@@ -17,22 +17,36 @@ $readableURL = new HyungJu\ReadableURL();
 
 You can pass three parameters to the class.
 ```php
+use HyungJu\ReadableURL;
 // Takes 3 parameters.
 // 1. A boolean value - If true, returns string in CamelCase, else lowercase.
 // 2. An integer value - The number of words to be generated in the string. (Between 2 and 10).
 // 3. A string - The seperator between the words.
 
-$readableURL = new HyungJu\ReadableURL();
+$readableURL = new ReadableURL();
 //$readableURL = new HyungJu\ReadableURL(false, 5, '-'); // Other options.
 ```
 
 To generate `ReadableURL`, call the `generate()` function.
 ```php
-$readableURL = new HyungJu\ReadableURL();
+use HyungJu\ReadableURL;
+
+...
+
+$readableURL = new ReadableURL();
 $readableURL->generate();
 // > QuickScrawnyCamp
 ```
 
+In addition, the following are simple to:
+```php
+use HyungJu\ReadableURL;
+
+...
+
+$str = ReadableURL::gen();
+// > FierceSaltyComparison
+```
 
 This can be used to add to the end of a URL.
 

--- a/src/ReadableURL.php
+++ b/src/ReadableURL.php
@@ -7,7 +7,7 @@ class ReadableURL
 
     private $capitalize;
     private $wordCount;
-    private $seperator;
+    private $separator;
 
     private $vowels;
     private $adjectives;
@@ -23,7 +23,7 @@ class ReadableURL
 
         $this->capitalize = $capitalize;
         $this->wordCount = $wordCount;
-        $this->seperator = $separator;
+        $this->separator = $separator;
 
         $this->vowels = ['a', 'e', 'i', 'o', 'u'];
         $this->adjectives = explode(" ", file_get_contents(__DIR__ . "/words/adjectives.txt"));
@@ -77,7 +77,7 @@ class ReadableURL
             $wordList = $this->convertToTitleCase($wordList);
         }
 
-        return implode($this->seperator, $wordList);
+        return implode($this->separator, $wordList);
     }
 
     public static function gen(bool $capitalize = true, int $wordCount = 3, string $separator = '') {

--- a/src/ReadableURL.php
+++ b/src/ReadableURL.php
@@ -2,9 +2,12 @@
 
 namespace HyungJu;
 
+/**
+ * readable-url
+ * Generate readable random phrases for URLs
+ */
 class ReadableURL
 {
-
     private $capitalize;
     private $wordCount;
     private $separator;
@@ -13,6 +16,14 @@ class ReadableURL
     private $adjectives;
     private $nouns;
 
+    /**
+     * ReadableURL constructor.
+     *
+     * @param bool $capitalize If true, returns string in CamelCase, else lowercase. (default: true)
+     * @param int $wordCount The number of words to be generated in the string. (Between 2 and 10). (default: 3)
+     * @param string $separator The separator between the words. (default: '')
+     * @throws \Exception
+     */
     function __construct(bool $capitalize = true, int $wordCount = 3, string $separator = '')
     {
         if ($wordCount < 2) {
@@ -30,6 +41,12 @@ class ReadableURL
         $this->nouns = explode(" ", file_get_contents(__DIR__ . "/words/nouns.txt"));
     }
 
+    /**
+     * 생성 시 단어들의 대문자 변환을 위한 함수.
+     *
+     * @param $wordsList
+     * @return mixed
+     */
     private function convertToTitleCase($wordsList)
     {
         for ($i = 0; $i < count($wordsList); $i++) {
@@ -39,6 +56,11 @@ class ReadableURL
         return $wordsList;
     }
 
+    /**
+     * readable-url 을 생성합니다.
+     *
+     * @return string
+     */
     public function generate()
     {
         $wordList = [];
@@ -80,7 +102,16 @@ class ReadableURL
         return implode($this->separator, $wordList);
     }
 
-    public static function gen(bool $capitalize = true, int $wordCount = 3, string $separator = '') {
+    /**
+     * readable-url 을 생성합니다. (shortcut)
+     *
+     * @param bool $capitalize If true, returns string in CamelCase, else lowercase. (default: true)
+     * @param int $wordCount The number of words to be generated in the string. (Between 2 and 10). (default: 3)
+     * @param string $separator The separator between the words. (default: '')
+     * @return string
+     * @throws \Exception
+     */
+    public static function gen(bool $capitalize = true, int $wordCount = 3, string $separator = ''): string {
         $class = new ReadableURL($capitalize, $wordCount, $separator);
         return $class->generate();
     }

--- a/src/ReadableURL.php
+++ b/src/ReadableURL.php
@@ -13,7 +13,7 @@ class ReadableURL
     private $adjectives;
     private $nouns;
 
-    function __construct(bool $capitalize = true, int $wordCount = 3, string $seperator = '')
+    function __construct(bool $capitalize = true, int $wordCount = 3, string $separator = '')
     {
         if ($wordCount < 2) {
             throw new \Exception('Minimum value expected: 2');
@@ -23,14 +23,14 @@ class ReadableURL
 
         $this->capitalize = $capitalize;
         $this->wordCount = $wordCount;
-        $this->seperator = $seperator;
+        $this->seperator = $separator;
 
         $this->vowels = ['a', 'e', 'i', 'o', 'u'];
         $this->adjectives = explode(" ", file_get_contents(__DIR__ . "/words/adjectives.txt"));
         $this->nouns = explode(" ", file_get_contents(__DIR__ . "/words/nouns.txt"));
     }
 
-    function convertToTitleCase($wordsList)
+    private function convertToTitleCase($wordsList)
     {
         for ($i = 0; $i < count($wordsList); $i++) {
             $wordsList[$i] = strtoupper($wordsList[$i][0]) . strtolower(substr($wordsList[$i], 1));
@@ -39,7 +39,7 @@ class ReadableURL
         return $wordsList;
     }
 
-    function generate()
+    public function generate()
     {
         $wordList = [];
 
@@ -78,5 +78,10 @@ class ReadableURL
         }
 
         return implode($this->seperator, $wordList);
+    }
+
+    public static function gen(bool $capitalize = true, int $wordCount = 3, string $separator = '') {
+        $class = new ReadableURL($capitalize, $wordCount, $separator);
+        return $class->generate();
     }
 }


### PR DESCRIPTION
## :books: docs
- README의 composer require 명령어 누락 해결
- README 예제에서의 `use` 사용.
- IDE에서의 간단한 사용을 위한 PHPDocs 추가.

## :zap: features
- `generate()`의 static shortcut `ReadableURL::gen()` 추가. params은 Class constructor와 동일
```php
ReadableURL::gen();
// output: FierceSaltyComparison
```