### PR TITLE
swap around the a and the an for english vowels

### DIFF
--- a/src/lang/en/En.php
+++ b/src/lang/en/En.php
@@ -13,12 +13,12 @@ class En extends Language
 
     public function getGluesForVowel()
     {
-        return ['a', 'the'];
+        return ['an', 'the'];
     }
 
     public function getGluesForNonVowel()
     {
-        return ['an'];
+        return ['a'];
     }
 
     public function getVowels()


### PR DESCRIPTION
Within the English language, you usually put "A" in front of words with a constant sound: "B, D, G" etc. When a word starts with a vowel, you put "an" infront of this word. So swapping them around would make more of the smaller urls grammatically correct (this cant how ever be 100% grammatically correct, since you'd have to build in a bunch of exceptions, but it will smooth it out a bit more :p)